### PR TITLE
Fix writing NBT tag lists

### DIFF
--- a/fastmc/proto.py
+++ b/fastmc/proto.py
@@ -852,6 +852,7 @@ def write_nbt(b, nbt):
         write_short_string(b, name)
         TAG_TYPES[nbt_tag.tag_type](b, nbt_tag.value)
     TAG_TYPES = {
+        NbtTag.END: lambda b: None,
         NbtTag.BYTE: write_byte,
         NbtTag.SHORT: write_short,
         NbtTag.INT: write_int,


### PR DESCRIPTION
Writing empty NBT tag lists will throw an exception since there is no writer for `NbtTag.END`

An example packet that exhibits the behaviour is below:

``` python
UpdateBlockEntity (0x35)
  location: Position(x=-2L, y=79L, z=-16L) (position_packed)
  action: 6 (ubyte)
  nbt: NBT(name=u'', root=NbtTag(tag_type=10, value={u'Patterns': NbtTag(tag_type=9, value=NbtList(tag_type=0, values=[])), u'Base': NbtTag(tag_type=3, value=0), u'y': NbtTag(tag_type=3, value=79), u'x': NbtTag(tag_type=3, value=-2), u'z': NbtTag(tag_type=3, value=-16), u'id': NbtTag(tag_type=8, value=u'Banner')})) (nbt)
```
